### PR TITLE
Change standard value of `ndsrd-process-coding-system' 

### DIFF
--- a/lisp/ndsrd.el
+++ b/lisp/ndsrd.el
@@ -55,7 +55,10 @@
   :type 'string
   :group 'ndsrd)
 
-(defcustom ndsrd-process-coding-system lookup-process-coding-system
+(defcustom ndsrd-process-coding-system
+  (if (memq system-type '(ms-dos windows-nt OS/2 emx))
+      'cp932
+    'euc-jp)
   "*Coding system for csrd process."
   :type 'symbol
   :group 'ndsrd)


### PR DESCRIPTION
Default charset of  `csrd` is different between Unix and Windows. It is EUC-JP on Unix and SHIFT_JIS on Windows.
But on Unix  `lookup-process-coding-system` is initialized to `'utf-8` unless explicitly specified.
It cause `ndsrd-process-cofing-system` to be set to same value, and results in charset mismatch on Unix.
Therefore standard value of  `ndsrd-process-coding-system` is changed  so that simply `'euc-jp`  is assigned on Unix and `'cp932` on Windows.
