### PR TITLE
Support $(STAGEDIR) in lisp/Makefile.am

### DIFF
--- a/lisp/Makefile.am
+++ b/lisp/Makefile.am
@@ -50,5 +50,5 @@ lookup-autoloads.el: $(SOURCES)
 	@$(EMACS) -batch -l lookup-compile.el -f lookup-autoload $(SOURCES)
 
 install: all
-	test -d @lispdir@/lookup || mkdir @lispdir@/lookup
-	install $(INSTALLFILES) @lispdir@/lookup
+	test -d $(DESTDIR)/@lispdir@/lookup || mkdir -p $(DESTDIR)/@lispdir@/lookup
+	install $(INSTALLFILES) $(DESTDIR)/@lispdir@/lookup


### PR DESCRIPTION
According to https://www.gnu.org/software/automake/manual/html_node/Staged-Installs.html automake generates support for the _DESTDIR_ variable in all install rules. But if you use your own install rule you must write that code to respect _DESTDIR._ Therefore I update `install` rule in `lisp/Makefile.am` so it respect _DESTDIR_.
