### PR TITLE
Fix usage of DESTDIR.

### DIFF
--- a/lisp/Makefile.am
+++ b/lisp/Makefile.am
@@ -50,5 +50,5 @@ lookup-autoloads.el: $(SOURCES)
 	@$(EMACS) -batch -l lookup-compile.el -f lookup-autoload $(SOURCES)
 
 install: all
-	test -d $(DESTDIR)/@lispdir@/lookup || mkdir -p $(DESTDIR)/@lispdir@/lookup
-	install $(INSTALLFILES) $(DESTDIR)/@lispdir@/lookup
+	test -d $(DESTDIR)@lispdir@/lookup || mkdir -p $(DESTDIR)@lispdir@/lookup
+	install $(INSTALLFILES) $(DESTDIR)@lispdir@/lookup


### PR DESCRIPTION
When DISTDIR is not specified "$(DESTDIR)/@lispdir@/lookup" is
expanded something like "//usr/local/share/emacs/sitelisp/lookup".  On
Unix it doesn't cause problem because "//" is same as "/". But on
Windows it is interpreted as specifying remote file path and may
result in error. So fix problem by changing it to
"$(DESTDIR)@lispdir@/lookup"